### PR TITLE
feat: update server mono

### DIFF
--- a/components/page/DefaultActionBar.tsx
+++ b/components/page/DefaultActionBar.tsx
@@ -171,7 +171,7 @@ const DefaultActionBar: React.FC<DefaultActionBarProps> = ({ items = [] }) => {
               },
               {
                 icon: '⊹',
-                children: 'Server Mono 0.0.7 [OFL]',
+                children: 'Server Mono [OFL]',
                 onClick: () => Utilities.onHandleFontChange('font-use-server-mono'),
               },
               {

--- a/global.scss
+++ b/global.scss
@@ -40,9 +40,9 @@
 
 @font-face {
   font-family: 'ServerMono';
-  src: url('https://intdev-global.s3.us-west-2.amazonaws.com/public/internet-dev/25071f6e-4cc8-4f91-8387-e4c60b9231de.woff2') format('woff2'),
-       url('https://intdev-global.s3.us-west-2.amazonaws.com/public/internet-dev/2bddcba4-a541-4af6-b4b6-5dfb1e4875f5.woff') format('woff'),
-       url('https://intdev-global.s3.us-west-2.amazonaws.com/public/internet-dev/45c36a19-7078-4880-89a5-2c700a28070a.otf') format('opentype');
+  src: url('https://cdn.jsdelivr.net/gh/internet-development/www-server-mono@latest/public/fonts/ServerMono-Regular.woff2') format('woff2'),
+       url('https://cdn.jsdelivr.net/gh/internet-development/www-server-mono@latest/public/fonts/ServerMono-Regular.woff') format('woff'),
+       url('https://cdn.jsdelivr.net/gh/internet-development/www-server-mono@latest/public/fonts/ServerMono-Regular.otf') format('opentype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
This pull request includes updates to the `Server Mono` font configuration and its usage across the application. The changes simplify the font name and update the font source URLs to use a new CDN.

### Font updates:

* [`components/page/DefaultActionBar.tsx`](diffhunk://#diff-561102b0072cf9a4976c3cb078223855afe6fbd264770afb8082b83edd7be242L174-R174): Updated the `children` property in the action bar to display `Server Mono [OFL]` instead of `Server Mono 0.0.7 [OFL]`.
* [`global.scss`](diffhunk://#diff-c85f19f4e9e4bab4b73b208e436d794a31d8aaec3601f3f2944542dd5a5d6f01L43-R45): Changed the `@font-face` `src` URLs for the `ServerMono` font to point to a new CDN (`cdn.jsdelivr.net`) for improved reliability and maintainability.